### PR TITLE
remove dist from nearestobs

### DIFF
--- a/R/nearestobs.R
+++ b/R/nearestobs.R
@@ -10,8 +10,6 @@
 #' @param species (required) Scientific name of the species of interest (not case 
 #' sensitive). See eBird taxonomy for more information: 
 #' http://ebird.org/content/ebird/about/ebird-taxonomy
-#' @param dist Distance defining radius of interest from given lat/lng in 
-#'    kilometers (between 0 and 50, defaults to 25)
 #' @param back Number of days back to look for observations (between
 #'    1 and 30, defaults to 14).
 #' @param max Maximum number of result rows to return in this request
@@ -50,7 +48,7 @@
 #' @references \url{http://ebird.org/}
 
 
-nearestobs <-  function(lat,lng, species, dist = NULL, back = NULL, 
+nearestobs <-  function(lat,lng, species, back = NULL, 
   max = NULL, locale = NULL, provisional = FALSE, 
   hotspot = FALSE, sleep = 0,
   ... #additional parameters inside curl
@@ -61,15 +59,13 @@ nearestobs <-  function(lat,lng, species, dist = NULL, back = NULL,
     
   Sys.sleep(sleep)
 
-  if(!is.null(dist))
-    dist <- round(dist)
   if(!is.null(back))
     back <- round(back)
   
   args <- compact(list(
   fmt='json', sci=species,
   lat=round(lat,2), lng=round(lng,2),
-  dist=dist, back=back, maxResults=max,
+  back=back, maxResults=max,
   locale=locale
   ))
 

--- a/man/nearestobs.Rd
+++ b/man/nearestobs.Rd
@@ -2,7 +2,7 @@
 \alias{nearestobs}
 \title{Nearest species sightings}
 \usage{
-  nearestobs(lat, lng, species, dist = NULL, back = NULL,
+  nearestobs(lat, lng, species, back = NULL,
     max = NULL, locale = NULL, provisional = FALSE,
     hotspot = FALSE, sleep = 0, ...)
 }
@@ -18,10 +18,6 @@
   of interest (not case sensitive). See eBird taxonomy for
   more information:
   http://ebird.org/content/ebird/about/ebird-taxonomy}
-
-  \item{dist}{Distance defining radius of interest from
-  given lat/lng in kilometers (between 0 and 50, defaults
-  to 25)}
 
   \item{back}{Number of days back to look for observations
   (between 1 and 30, defaults to 14).}


### PR DESCRIPTION
Nearest Locations doesn't accept dist paramater (https://confluence.cornell.edu/display/CLOISAPI/eBird-1.1-NearestLocationsWithObservationsOfASpecies). Forgive me if I've messed anything up; this is my first pull request.
