### PR TITLE
Coerce ebird_GET output to tbl_df as bind_rows does not, bump version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rebird
-Version: 0.3.1
+Version: 0.3.2
 Date: 2016-03-23
 Title: R Client for the eBird Database of Bird Observations
 Description: A programmatic client for the eBird database, including functions

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,7 +26,7 @@ ebird_GET <- function(url, args, ...){
           }
         }
       }))
-      bind_rows(lapply(json, data.frame, stringsAsFactors = FALSE))
+      tbl_df(bind_rows(lapply(json, data.frame, stringsAsFactors = FALSE)))
     }
   }
 }


### PR DESCRIPTION
The test for `ebirdtaxonomy` was failing as it  was expecting a `tbl_df` object to be returned, however the new function dplyr::bind_rows we use instead of `rbind_all` when calling `ebird_GET` does not coerce everything to `tbl_df` and was returning an object of class `data.frame` only.

Wrapping `ebird_GET`'s output in `tbl_df()` fixes this.