### PR TITLE
Update ebird_GET return line with @andyteucher's suggestion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rebird
-Version: 0.3.2
+Version: 0.3.3
 Date: 2016-03-23
 Title: R Client for the eBird Database of Bird Observations
 Description: A programmatic client for the eBird database, including functions

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,7 +26,7 @@ ebird_GET <- function(url, args, ...){
           }
         }
       }))
-      tbl_df(bind_rows(lapply(json, data.frame, stringsAsFactors = FALSE)))
+      bind_rows(lapply(json, as_data_frame))
     }
   }
 }


### PR DESCRIPTION
Replaced `data.frame` to `dplyr::as_data_frame`, as suggested by @ateucher,  to avoid need for `tbl_df` and `stringsAsFactor` argument.