### PR TITLE
Fix ebirdfreq, associated tests, and update deprecated testthat functions, closes #52

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rebird
-Version: 0.3.3
+Version: 0.3.4
 Date: 2016-03-23
 Title: R Client for the eBird Database of Bird Observations
 Description: A programmatic client for the eBird database, including functions

--- a/R/ebirdfreq.R
+++ b/R/ebirdfreq.R
@@ -13,8 +13,9 @@
 #'   "CA-BC-GV"). 
 #'   If querying hotspots then the unique identifier is a 6-digit
 #'   number prepended with an "L" (e.g. "L196159"). All these codes
-#'   can be found by looking at the URL in the Explore Data eBird
-#'   page (http://ebird.org//GuideMe?cmd=changeLocation).
+#'   can be found by looking at the URL in each respective
+#'   location/hotspot webpage (which are accessible through the 
+#'   "Explore Data" tab).
 #' @param startyear Starting year for query. Defaults to 1900.
 #' @param endyear Ending year for query. Defaults to current year 
 #'   specified by Sys.Date().
@@ -68,14 +69,10 @@ ebirdfreq <- function(loctype, loc, startyear = 1900,
     stop("Not a valid location type")
   }
   
-  args <- list(cmd = "getChart", displayType = "download", 
-               getLocations = loctype, loctypename = loc, 
-               bYear = startyear, eYear = endyear, bMonth = startmonth, 
-               eMonth = endmonth)
-  # Rename the loctypename placeholder with loctype
-  names(args)[names(args) == "loctypename"] <- loctype
-  
-  url <- "http://ebird.org/ebird/BarChart"
+  args <- list(r = loc, byr = startyear, eyr = endyear, bmo = startmonth, 
+               emo = endmonth, fmt = "tsv")
+
+  url <- "http://ebird.org/ebird/barchartData"
   ret <- GET(url, query = args, ...)
   stop_for_status(ret)
   asChar <- readBin(ret$content, "character")
@@ -101,4 +98,3 @@ ebirdfreq <- function(loctype, loc, startyear = 1900,
     tbl_df(freq_long)
   }
 }
-

--- a/tests/testthat/test-ebirdfreq.R
+++ b/tests/testthat/test-ebirdfreq.R
@@ -25,7 +25,9 @@ test_that("ebirdfreq fails correctly", {
   expect_error(ebirdfreq("hotspots", "foo123"), "Invalid hotspot code")
   expect_error(ebirdfreq("country"), "Not a valid location type")
   expect_error(ebirdfreq("counties", "CA-BC-ZZ"), "Specified location doesn't exist")
-  expect_warning(ebirdfreq("hotspots", "L196159", 1901, 1902, long = FALSE), "No observations returned")
+  expect_error(ebirdfreq("hotspots", "L196159", 1901, 1902, long = FALSE), regexp = "^Internal Server Error \\(HTTP 500\\)\\.$")
+  # for some reason the following fails:
+  # expect_error(ebirdfreq("hotspots", "L196159", 1900, 1902, long = FALSE), "Internal Server Error (HTTP 500).")
   expect_error(ebirdfreq("foo", "CA-BC-ZZ"), "Not a valid location type")
 })
-
+ 

--- a/tests/testthat/test-ebirdgeo.R
+++ b/tests/testthat/test-ebirdgeo.R
@@ -10,6 +10,6 @@ test_that("ebirdgeo works correctly", {
   expect_is(egeo$howMany, "integer")
   expect_is(ebirdgeo(lat = 42, lng = -76, max=10, provisional=TRUE, hotspot=TRUE), "data.frame")
   expect_equal(nrow(ebirdgeo(lat = 42, lng = -76, max=10, provisional=TRUE, hotspot=TRUE)), 10)
-  expect_that(ebirdgeo(lat = 40, lng = -120, dist = 50), not(gives_warning()))
+  expect_silent(ebirdgeo(lat = 40, lng = -120, dist = 50))
   expect_warning(ebirdgeo(lat = 30, lng = -120, dist = 100), "Distance supplied was >50km")
 })

--- a/tests/testthat/test-ebirdhotspot.R
+++ b/tests/testthat/test-ebirdhotspot.R
@@ -6,7 +6,7 @@ test_that("ebirdhotspot works correctly", {
   out <- ebirdhotspot('L99381', max=10, provisional=TRUE)
   expect_is(out, "data.frame")
   expect_is(out$comName, "character")
-  expect_that(ebirdhotspot('L99381'), not(gives_warning()))
+  expect_silent(ebirdhotspot('L99381'))
   
   expect_warning(ebirdhotspot(locID = 'L99381', back = 40))
 })

--- a/tests/testthat/test-ebirdloc.R
+++ b/tests/testthat/test-ebirdloc.R
@@ -13,10 +13,10 @@ test_that("ebirdloc works correctly", {
   
   simpler <- ebirdloc('L99381', max = 1, simple = TRUE)
   lesssimpler <- ebirdloc('L99381', max = 1, simple = FALSE)
-  expect_less_than(NCOL(simpler), 15)
-  expect_that(NCOL(simpler), not(is_less_than(8)))
-  expect_less_than(NCOL(lesssimpler), 30)
-  expect_that(NCOL(lesssimpler), not(is_less_than(10)))
+  expect_lt(NCOL(simpler), 15)
+  expect_gt(NCOL(simpler), 8)
+  expect_lt(NCOL(lesssimpler), 30)
+  expect_gt(NCOL(lesssimpler), 10)
 })
 
 

--- a/tests/testthat/test-ebirdnotable.R
+++ b/tests/testthat/test-ebirdnotable.R
@@ -16,7 +16,7 @@ test_that("ebirdnotable works correctly", {
   expect_equal(dim(simpler), c(40,11))
 #   expect_equal(dim(lesssimpler), c(40,24))
   
-  expect_more_than(
+  expect_gt(
     system.time(ebirdnotable(lat=42, lng=-70, max = 10, sleep = 1))[[3]]
     , 1)
 })


### PR DESCRIPTION
I updated `ebirdfreq` to reflect changes to the way the website links to the .csv download, removed a broken link in the documentation for this function, and fixed one associated test that was throwing an error. Interestingly, `expect_error` thinks the error messages are different even though they seem identical:
``` r
expect_error(ebirdfreq("hotspots", "L196159", 1900, 1902, long = FALSE), 
                         "Internal Server Error (HTTP 500).")
# Error: error$message does not match "Internal Server Error (HTTP 500).".
# Actual value: "Internal Server Error (HTTP 500)."
```

However, the following regexp matches the whole string with no problem (I kept this regexp in the test): 

``` r
expect_error(ebirdfreq("hotspots", "L196159", 1901, 1902, long = FALSE), 
                         regexp = "^Internal Server Error \\(HTTP 500\\)\\.$")
```

Any ideas why @sckott ?

As a separate commit, I updated all `testthat` functions that were deprecated; they were producing warnings in the tests.