### PR TITLE
API V2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Suggests:
     knitr,
     testthat,
     covr
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.1.0
 X-schema.org-applicationCategory: Data Access
 X-schema.org-keywords: birds, birding, ebird, database, data, biology, observations, sightings, ornithology
 X-schema.org-isPartOf: https://ropensci.org

--- a/R/ebirdregion.R
+++ b/R/ebirdregion.R
@@ -9,8 +9,9 @@
 #' (e.g. "US"), "subnational1" (states/provinces, e.g. "US-NV") or
 #' "subnational" (counties, not yet implemented, e.g. "US-NY-109"). Default
 #' behavior is to try and match according to the region specified.
-#' @param species scientific name of the species of interest (not case
-#' sensitive). Defaults to NULL, in which case sightings for all species are returned.
+#' @param species eBird species code. See \code{\link{ebirdtaxonomy}} for a full
+#' list of scientific names, common names, and species codes. 
+#' Defaults to NULL, in which case sightings for all species are returned.
 #' See eBird taxonomy for more information:
 #' http://ebird.org/content/ebird/about/ebird-taxonomy
 #' @param back Number of days back to look for observations (between
@@ -45,7 +46,7 @@
 #' @return "sciName" species' scientific name
 #' @export
 #' @examples \dontrun{
-#' ebirdregion(region = 'US', species = 'Setophaga caerulescens')
+#' ebirdregion(region = 'US', species = 'btbwar')
 #' ebirdregion('US-OH', max=10, provisional=TRUE, hotspot=TRUE)
 #' }
 #' @author Rafael Maia \email{rm72@@zips.uakron.edu}
@@ -55,19 +56,14 @@ ebirdregion <-  function(region, species = NULL, regtype = NULL, back = NULL, ma
   locale = NULL, provisional = FALSE, hotspot = FALSE, sleep = 0, ...)
 {
   Sys.sleep(sleep)
-  url <- paste0(ebase(), 'data/obs/', if(!is.null(species)) 'region_spp/recent' else 'region/recent')
+  url <- paste0(ebase(), 'data/obs/', region, '/recent/', species)
 
-  if(!is.null(regtype))
-    regtype <- match.arg(regtype, choices = c("country", "subnational1", "subnational2"))
-  if(!is.null(back)) back <- round(back)
+  if (!is.null(back)) back <- round(back)
 
-  args <- ebird_compact(list(
-    fmt='json', r=region, rtype=regtype,
-    sci=species, back=back,
-    maxResults=max, locale=locale
-  ))
-  if(provisional) args$includeProvisional <- 'true'
-  if(hotspot) args$hotspot <- 'true'
+  args <- list(back=back, maxResults=max, locale=locale)
+  
+  if (provisional) args$includeProvisional <- 'true'
+  if (hotspot) args$hotspot <- 'true'
   
   ebird_GET(url, args, ...)
 }

--- a/R/ebirdtaxonomy.R
+++ b/R/ebirdtaxonomy.R
@@ -37,6 +37,6 @@ ebirdtaxonomy <- function(cat=NULL, locale=NULL, ...){
     stop("You have supplied an invalid species category")
   }
   cat <- if(!is.null(cat)) cat <- paste0(cat, collapse = ",")
-  args <- ebird_compact(list(fmt='json', cat=cat, locale=locale))
+  args <- list(fmt='json', cat=cat, locale=locale)
   ebird_GET(paste0(ebase(), 'ref/taxonomy/ebird'), args, ...)
 }

--- a/R/ebirdtaxonomy.R
+++ b/R/ebirdtaxonomy.R
@@ -38,5 +38,5 @@ ebirdtaxonomy <- function(cat=NULL, locale=NULL, ...){
   }
   cat <- if(!is.null(cat)) cat <- paste0(cat, collapse = ",")
   args <- ebird_compact(list(fmt='json', cat=cat, locale=locale))
-  ebird_GET(paste0(ebase(), 'ref/taxa/ebird'), args, ...)
+  ebird_GET(paste0(ebase(), 'ref/taxonomy/ebird'), args, ...)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -7,9 +7,11 @@ ebase <- function() 'https://ebird.org/ws2.0/'
 ebird_key <- Sys.getenv("EBIRD_KEY")
 
 ebird_GET <- function(url, args, ...){
-  tt <- GET(URLencode(url), query = args, 
+  tt <- GET(URLencode(url), 
+            query = ebird_compact(args), 
             config = add_headers("X-eBirdApiToken" = Sys.getenv("EBIRD_KEY")), 
             ...)
+  
   ss <- content(tt, as = "text", encoding = "UTF-8")
   json <- jsonlite::fromJSON(ss, FALSE)
   if (tt$status_code > 202) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,10 +2,14 @@
 
 ebird_compact <- function(x) Filter(Negate(is.null), x)
 
-ebase <- function() 'https://ebird.org/ws1.1/'
+ebase <- function() 'https://ebird.org/ws2.0/'
+
+ebird_key <- Sys.getenv("EBIRD_KEY")
 
 ebird_GET <- function(url, args, ...){
-  tt <- GET(url, query = args, ...)
+  tt <- GET(URLencode(url), query = args, 
+            config = add_headers("X-eBirdApiToken" = Sys.getenv("EBIRD_KEY")), 
+            ...)
   ss <- content(tt, as = "text", encoding = "UTF-8")
   json <- jsonlite::fromJSON(ss, FALSE)
   if (tt$status_code > 202) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -4,12 +4,12 @@ ebird_compact <- function(x) Filter(Negate(is.null), x)
 
 ebase <- function() 'https://ebird.org/ws2.0/'
 
-ebird_key <- Sys.getenv("EBIRD_KEY")
+get_key <- function() Sys.getenv("EBIRD_KEY")
 
 ebird_GET <- function(url, args, ...){
   tt <- GET(URLencode(url), 
             query = ebird_compact(args), 
-            config = add_headers("X-eBirdApiToken" = Sys.getenv("EBIRD_KEY")), 
+            config = add_headers("X-eBirdApiToken" = get_key()), 
             ...)
   
   ss <- content(tt, as = "text", encoding = "UTF-8")

--- a/man/ebirdregion.Rd
+++ b/man/ebirdregion.Rd
@@ -13,8 +13,9 @@ ebirdregion(region, species = NULL, regtype = NULL, back = NULL,
 For supported region and coding, see
 https://confluence.cornell.edu/display/CLOISAPI/eBird-1.1-RegionCodeReference}
 
-\item{species}{scientific name of the species of interest (not case
-sensitive). Defaults to NULL, in which case sightings for all species are returned.
+\item{species}{eBird species code. See \code{\link{ebirdtaxonomy}} for a full
+list of scientific names, common names, and species codes. 
+Defaults to NULL, in which case sightings for all species are returned.
 See eBird taxonomy for more information:
 http://ebird.org/content/ebird/about/ebird-taxonomy}
 
@@ -78,7 +79,7 @@ Returns the most recent sighting information reported in a given region.
 }
 \examples{
 \dontrun{
-ebirdregion(region = 'US', species = 'Setophaga caerulescens')
+ebirdregion(region = 'US', species = 'btbwar')
 ebirdregion('US-OH', max=10, provisional=TRUE, hotspot=TRUE)
 }
 }

--- a/tests/testthat/test-ebirdregion.R
+++ b/tests/testthat/test-ebirdregion.R
@@ -3,16 +3,16 @@ context("ebirdregion")
 test_that("ebirdregion works correctly", {
   skip_on_cran()
   
-  out <- ebirdregion(region = 'US', species = 'Setophaga caerulescens', max = 50)
+  out <- ebirdregion(region = 'US', species = 'btbwar', max = 50)
   expect_is(out, "data.frame")
-  expect_equal(NCOL(out), 12)
+  expect_equal(ncol(out), 12)
   expect_is(out$comName, "character")
   expect_is(out$howMany, "integer")
 
   expect_equal(dim(ebirdregion('US-OH', max=10, provisional=TRUE, hotspot=TRUE)), c(10,12))
   
   res <- ebirdregion(region = 'US-CA', max = 10)
-  expect_equal(NCOL(res), 12)
+  expect_equal(ncol(res), 12)
   
-  expect_equal(NCOL(ebirdregion(region = 'US', species = 'Accipiter gentilis')), 12)
+  expect_equal(ncol(ebirdregion(region = 'US', species = 'coohaw')), 12)
 })

--- a/tests/testthat/test-ebirdtaxonomy.R
+++ b/tests/testthat/test-ebirdtaxonomy.R
@@ -12,7 +12,7 @@ test_that("ebirdtaxonomy works correctly", {
   expect_is(out2, "tbl_df")
   
   expect_is(out$comName, "character")
-  expect_is(out$taxonID, "character")
+  expect_is(out$taxonOrder, "numeric")
 })
 
 test_that("ebirdtaxonomy fails correctly", {


### PR DESCRIPTION
**Not ready for merge**

I've started the migration to API v2.0 (#58, #63) here by:

- changing `ebird_GET()` to talk to the new API and pass an API key (stored in an environment variable `EBIRD_KEY`)
- making `ebirdtaxonomy()` and `ebirdregion()` work with new API

User facing changes (so far):
- Need an API key
- `species` is no longer passed as a scientific name but rather as an ebird species code (generally 6-7 characters, eg., `cangoo` for Canada Goose, `coohaw` for Cooper's Hawk)

I don't have push access to the main repo so I've started this in my fork. If other people want to contribute I can add them as collaborators here or @sckott can add me on the main repo and I can move this over there...