### PR TITLE
Update ebird API url, existing gives 404

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ knitr::opts_chunk$set(
 
 eBird is a real-time, online bird checklist program. For more information, visit their website: http://www.ebird.org
 
-The API for the eBird webservices can be accessed here: https://documenter.getpostman.com/view/664302/ebird-api-20/2HTbHW
+The API for the eBird webservices can be accessed here: https://documenter.getpostman.com/view/664302/S1ENwy59?version=latest
 
 ## Install
 
@@ -52,7 +52,7 @@ Load the package:
 library("rebird")
 ```
 
-The [eBird API server](https://documenter.getpostman.com/view/664302/ebird-api-20/2HTbHW) 
+The [eBird API server](https://documenter.getpostman.com/view/664302/S1ENwy59?version=latest)
 has been updated and thus there are a couple major changes in the way `rebird` works.
 API requests to eBird now require users to provide an API key, which is linked to your 
 eBird user account. 


### PR DESCRIPTION
hi folks, I was poking around looking for a way to get into rebird for hacktoberfest, and I noticed the URL for the ebird API was no longer working, thought I'd try to help