### PR TITLE
Implement ebirdsubregionlist, to cover ref/region/list/ API endpoint.

### DIFF
--- a/R/ebirdregioninfo.R
+++ b/R/ebirdregioninfo.R
@@ -45,6 +45,10 @@ ebirdregioninfo <- function(loc, format = "full", key = NULL, ...) {
     stop("More than one location specified")
   }
   
+  if (nchar(as.character(loc)) == 0) {
+    stop("Location must not be empty")
+  }
+  
   args <- list(regionNameFormat = format) 
   
   regtype <- "region" 

--- a/R/ebirdsubregionlist.R
+++ b/R/ebirdsubregionlist.R
@@ -3,9 +3,9 @@
 #' @param regionType The type of region to search for. Must be one of 'country',
 #'  'subnational1' or 'subnational2'.
 #' @param parentRegionCode The region to search within. Must be a valid 
-#' country or subnational1 code, or 'world'. (The latter is only valid when 
-#' searching for regionType of 'country').
-#' @param key ebird API key. You can obtain one from https://ebird.org/api/keygen.
+#' country or subnational1 code. If `regionType` is 'country' then this 
+#' parameter is ignored (since the search will automatically be world-wide).
+#' @param key eBird API key. You can obtain one from https://ebird.org/api/keygen.
 #'    We strongly recommend storing it in your \code{.Renviron} file as an
 #'    environment variable called \code{EBIRD_KEY}.
 #' @param ... Curl options passed on to \code{\link[httr]{GET}}
@@ -17,7 +17,7 @@
 #' @export
 #'
 #' @examples \dontrun{
-#' ebirdsubregionlist("country", "world")
+#' ebirdsubregionlist("country")
 #' ebirdsubregionlist("subnational1", "US")
 #' ebirdsubregionlist("subnational2", "US-NY")
 #' }
@@ -28,9 +28,7 @@ ebirdsubregionlist <- function(regionType = c("country", "subnational1", "subnat
   regionType <- match.arg(regionType)
 
   if (regionType == "country") {
-    if (parentRegionCode != "world") {
-      stop("Invalid input: can only choose regionType of 'country' with parentRegionCode of 'world'.")
-    }
+    parentRegionCode = "world"
   } else {
     # check whether region code exists
     invisible(ebirdregioninfo(parentRegionCode, key = key))

--- a/R/ebirdsubregionlist.R
+++ b/R/ebirdsubregionlist.R
@@ -32,6 +32,9 @@ ebirdsubregionlist <- function(regionType = c("country", "subnational1", "subnat
   } else {
     # check whether region code exists
     invisible(ebirdregioninfo(parentRegionCode, key = key))
+    if (grepl("[A-Z]{2}-[A-Z]{2,3}-[A-Z0-9]{2,3}", parentRegionCode)) {
+      stop("Value of 'parentRegionCode' is subnational2. Change to subnational1 or country code.")
+    }
   }
   
   url <- paste0(ebase(), "ref/region/list/", regionType, "/", parentRegionCode)

--- a/R/ebirdsubregionlist.R
+++ b/R/ebirdsubregionlist.R
@@ -1,0 +1,44 @@
+#' List sub-regions within a specified region.
+#'
+#' @param regionType The type of region to search for. Must be one of 'country',
+#'  'subnational1' or 'subnational2'.
+#' @param parentRegionCode The region to search within. Must be a valid 
+#' country or subnational1 code, or 'world'. (The latter is only valid when 
+#' searching for regionType of 'country').
+#' @param key ebird API key. You can obtain one from https://ebird.org/api/keygen.
+#'    We strongly recommend storing it in your \code{.Renviron} file as an
+#'    environment variable called \code{EBIRD_KEY}.
+#' @param ... Curl options passed on to \code{\link[httr]{GET}}
+#'
+#' @return A data.frame containing:
+#' @return "code": eBird code for the subregion
+#' @return "name": full name for the subregion
+
+#' @export
+#'
+#' @examples \dontrun{
+#' ebirdsubregionlist("country", "world")
+#' ebirdsubregionlist("subnational1", "US")
+#' ebirdsubregionlist("subnational2", "US-NY")
+#' }
+#' @author David Bradnum \email{dbradnum@@gmail.com}
+#' @references \url{http://ebird.org/}
+ebirdsubregionlist <- function(regionType = c("country", "subnational1", "subnational2"),
+                               parentRegionCode, key = NULL, ...) {
+  regionType <- match.arg(regionType)
+
+  if (regionType == "country") {
+    if (parentRegionCode != "world") {
+      stop("Invalid input: can only choose regionType of 'country' with parentRegionCode of 'world'.")
+    }
+  } else {
+    # check whether region code exists
+    invisible(ebirdregioninfo(parentRegionCode, key = key))
+  }
+  
+  url <- paste0(ebase(), "ref/region/list/", regionType, "/", parentRegionCode)
+
+  args <- list()
+
+  ebird_GET(url, args, key = key, ...)
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -176,6 +176,11 @@ or a hotspot
 ebirdregionspecies("L5803024")
 ```
 
+Obtain a list of all subregions within an eBird region
+
+```{r ebirdsubregionlist}
+ebirdsubregionlist("subnational1","US")
+```
 
 ## Checklist Feed
 
@@ -232,8 +237,8 @@ The 2.0 APIs have considerably been expanded from the previous version, and `reb
 
 ### ref/region
  - [x]     Hotspot Info: `ebirdregioninfo()`
- - [x]    Region Info: `ebirdregioninfo()`
- - [ ]     Sub Region List
+ - [x]     Region Info: `ebirdregioninfo()`
+ - [x]     Sub Region List
 
 
 ## Meta

--- a/README.Rmd
+++ b/README.Rmd
@@ -238,7 +238,7 @@ The 2.0 APIs have considerably been expanded from the previous version, and `reb
 ### ref/region
  - [x]     Hotspot Info: `ebirdregioninfo()`
  - [x]     Region Info: `ebirdregioninfo()`
- - [x]     Sub Region List
+ - [x]     Sub Region List `ebirdsubregionlist()`
 
 
 ## Meta

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ covered by this package, feel free to submit a pull request\!
 
   - [x] Hotspot Info: `ebirdregioninfo()`
   - [x] Region Info: `ebirdregioninfo()`
-  - [x] Sub Region List
+  - [x] Sub Region List `ebirdsubregionlist()`
 
 ## Meta
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,27 @@ ebirdregioninfo("L196159")
 #> #   lng <dbl>, hierarchicalName <chr>, locID <chr>
 ```
 
+Obtain a list of all subregions within an eBird region
+
+``` r
+ebirdsubregionlist("subnational1","US")
+#> # A tibble: 51 x 2
+#>    code  name                
+#>    <chr> <chr>               
+#>  1 US-AL Alabama             
+#>  2 US-AK Alaska              
+#>  3 US-AZ Arizona             
+#>  4 US-AR Arkansas            
+#>  5 US-CA California          
+#>  6 US-CO Colorado            
+#>  7 US-CT Connecticut         
+#>  8 US-DE Delaware            
+#>  9 US-DC District of Columbia
+#> 10 US-FL Florida             
+#> # ... with 41 more rows
+```
+
+
 ## Checklist Feed
 
 Obtain a list of checklists submitted on a given date at a region or
@@ -408,7 +429,7 @@ covered by this package, feel free to submit a pull request\!
 
   - [x] Hotspot Info: `ebirdregioninfo()`
   - [x] Region Info: `ebirdregioninfo()`
-  - [ ] Sub Region List
+  - [x] Sub Region List
 
 ## Meta
 

--- a/tests/testthat/test-ebirdsubregionlist.R
+++ b/tests/testthat/test-ebirdsubregionlist.R
@@ -3,7 +3,7 @@ context("ebirdsubregionlist")
 test_that("ebirdsubregionlist works correctly", {
   skip_on_cran()
   
-  countries = ebirdsubregionlist("country", "world")
+  countries = ebirdsubregionlist("country")
   
   expect_is(countries, "data.frame")
   expect_is(countries, "tbl_df")
@@ -27,7 +27,6 @@ test_that("ebirdsubregionlist works correctly", {
 test_that("ebirdsubregionlist fails correctly", {
   skip_on_cran()
   
-  expect_error(ebirdsubregionlist("country", "US"))
   expect_error(ebirdsubregionlist("foo", "US"))
   expect_error(ebirdsubregionlist("subnational1", "foo"))
   expect_error(ebirdsubregionlist("subnational2", c("US-NY","US-NV")))

--- a/tests/testthat/test-ebirdsubregionlist.R
+++ b/tests/testthat/test-ebirdsubregionlist.R
@@ -1,0 +1,37 @@
+context("ebirdsubregionlist")
+
+test_that("ebirdsubregionlist works correctly", {
+  skip_on_cran()
+  
+  countries = ebirdsubregionlist("country", "world")
+  
+  expect_is(countries, "data.frame")
+  expect_is(countries, "tbl_df")
+  
+  expect_equal(NCOL(countries), 2)
+  expect_gt(NROW(countries), 200)
+  expect_is(countries$code, "character")
+  
+  us1 = ebirdsubregionlist("subnational1", "US")
+  us2 = ebirdsubregionlist("subnational2", "US")
+  ny2 = ebirdsubregionlist("subnational2", "US-NY")
+  
+  expect_is(us1, "data.frame")
+  expect_is(us1, "tbl_df")
+  expect_equal(NCOL(us1), 2)
+  
+  expect_gt(NROW(us2),NROW(us1))
+  expect_gt(NROW(us2),NROW(ny2))
+})
+
+test_that("ebirdsubregionlist fails correctly", {
+  skip_on_cran()
+  
+  expect_error(ebirdsubregionlist("country", "US"))
+  expect_error(ebirdsubregionlist("foo", "US"))
+  expect_error(ebirdsubregionlist("subnational1", "foo"))
+  expect_error(ebirdsubregionlist("subnational2", c("US-NY","US-NV")))
+  expect_error(ebirdsubregionlist(c("subnational1","subnational2"), "US"))
+  expect_error(ebirdsubregionlist("subnational1", ""))
+})
+


### PR DESCRIPTION
## Description
Tidying up another snippet of code I had locally, to implement another missing API endpoint - this time to find eBird subregions within a given region. 

I hope this is useful and doesn't create much additional work while you're preparing for a new release. However, let me know if you spot any problem or would prefer not to merge this in at the moment. 

## Example
```
ebirdsubregionlist("country", "world")
ebirdsubregionlist("subnational1", "US")
ebirdsubregionlist("subnational2", "US-NY")

```
