### PR TITLE
temporarily skip some tests on GitHub Actions

### DIFF
--- a/tests/testthat/test-ebirdchecklistfeed.R
+++ b/tests/testthat/test-ebirdchecklistfeed.R
@@ -2,6 +2,7 @@ context("ebirdchecklistfeed")
 
 test_that("ebirdchecklistfeed succeeds reproducibly", {
   skip_on_cran()
+  skip_on_ci()
   
   out1 <- ebirdchecklistfeed(loc = "L207391", date = "2020-03-24", max = 3)
   expect_is(out1, "data.frame")
@@ -12,6 +13,7 @@ test_that("ebirdchecklistfeed succeeds reproducibly", {
 
 test_that("ebirdchecklistfeed errors for bad input", {
   skip_on_cran()
+  skip_on_ci()
   
   expect_warning(ebirdchecklistfeed(loc = "L207391", date = "2020-03-24", max = 250))
   expect_error(ebirdchecklistfeed(loc = "L207391", date = "2121-03-25"))

--- a/tests/testthat/test-ebirdgeo.R
+++ b/tests/testthat/test-ebirdgeo.R
@@ -2,6 +2,7 @@ context("ebirdgeo")
 
 test_that("ebirdgeo works correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   egeo <- ebirdgeo('amegfi',42,-76)
   expect_is(egeo, "data.frame")

--- a/tests/testthat/test-ebirdhistorical.R
+++ b/tests/testthat/test-ebirdhistorical.R
@@ -2,6 +2,7 @@ context("ebirdhistorical")
 
 test_that("ebirdhistorical works correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   out <- ebirdhistorical(loc = 'US-VA-003', date = '2017-03-19')
   expect_is(out, "data.frame")

--- a/tests/testthat/test-ebirdhotspot.R
+++ b/tests/testthat/test-ebirdhotspot.R
@@ -2,6 +2,7 @@ context("ebirdhotspot")
 
 test_that("ebirdhotspot works correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   expect_warning(out <- ebirdhotspot('L99381', max = 10, provisional = TRUE))
   expect_is(out, "data.frame")

--- a/tests/testthat/test-ebirdhotspotlist.R
+++ b/tests/testthat/test-ebirdhotspotlist.R
@@ -2,6 +2,7 @@ context("ebirdhotspotlist")
 
 test_that("ebirdhotspotlist works correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   out <- ebirdhotspotlist("CA-NS-YA")
   out2 <- ebirdhotspotlist(lat = 30, lng = -90, dist = 10)

--- a/tests/testthat/test-ebirdloc.R
+++ b/tests/testthat/test-ebirdloc.R
@@ -2,6 +2,7 @@ context("ebirdloc")
 
 test_that("ebirdloc works correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   expect_warning(out <- ebirdloc(c('L99381','L99382')))
   expect_is(out, "data.frame")

--- a/tests/testthat/test-ebirdnotable.R
+++ b/tests/testthat/test-ebirdnotable.R
@@ -2,6 +2,7 @@ context("ebirdnotable")
 
 test_that("ebirdnotable works correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   out <- ebirdnotable(lat=42, lng=-70, max = 40)
   expect_is(out, "data.frame")

--- a/tests/testthat/test-ebirdregion.R
+++ b/tests/testthat/test-ebirdregion.R
@@ -2,6 +2,7 @@ context("ebirdregion")
 
 test_that("ebirdregion works correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   out <- ebirdregion(loc = 'US', species = 'btbwar', max = 50)
   expect_is(out, "data.frame")

--- a/tests/testthat/test-ebirdregioncheck.R
+++ b/tests/testthat/test-ebirdregioncheck.R
@@ -2,6 +2,7 @@ context("ebirdregioncheck")
 
 test_that("ebirdregioncheck works correctly", {
   skip_on_cran()
+  skip_on_ci()
  
   expect_warning(expect_is(ebirdregioncheck("CA"), "logical"))
   expect_warning(expect_equal(ebirdregioncheck("CA"), TRUE))

--- a/tests/testthat/test-ebirdregioninfo.R
+++ b/tests/testthat/test-ebirdregioninfo.R
@@ -2,6 +2,7 @@ context("ebirdregioninfo")
 
 test_that("ebirdregioninfo works correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   us <- ebirdregioninfo("US")
   
@@ -25,6 +26,7 @@ test_that("ebirdregioninfo works correctly", {
 
 test_that("ebirdregioninfo fails correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   expect_error(ebirdregioninfo())
   expect_error(ebirdregioninfo("foo"), class = "error")

--- a/tests/testthat/test-ebirdregionspecies.R
+++ b/tests/testthat/test-ebirdregionspecies.R
@@ -2,6 +2,7 @@ context("ebirdregionspecies")
 
 test_that("ebirdregionspecies works correctly", {
   skip_on_cran()
+  skip_on_ci()
 
   eng <- ebirdregionspecies("GB-ENG")
   lon <- ebirdregionspecies("GB-ENG-LND")

--- a/tests/testthat/test-ebirdsubregionlist.R
+++ b/tests/testthat/test-ebirdsubregionlist.R
@@ -2,6 +2,7 @@ context("ebirdsubregionlist")
 
 test_that("ebirdsubregionlist works correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   countries = ebirdsubregionlist("country")
   

--- a/tests/testthat/test-nearestobs.R
+++ b/tests/testthat/test-nearestobs.R
@@ -2,6 +2,7 @@ context("nearestobs")
 
 test_that("nearestobs works correctly", {
   skip_on_cran()
+  skip_on_ci()
   
   out <- nearestobs('cangoo', 42, -76)
   out2 <- nearestobs('cangoo', 42,-76, max=10, provisional=TRUE, hotspot=TRUE)


### PR DESCRIPTION
PR to temporarily skip some tests on GitHub Actions. This gets repo to an intermediate state where the non-test portion of package checks pass on GitHub Actions. Then can work on tests in future PR to get those working on GitHub Actions as well.

Addresses #100 but is not yet a complete fix for #91.