### PR TITLE
VCR testing setup and VCR testing for ebirdchecklistfeed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+tests/fixtures/**/* -diff

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .Rhistory
 .RData
 *.Rproj
-.gitattributes
 krlocal.R
 /.Rapp.history
 .DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ Suggests:
     knitr,
     rmarkdown,
     testthat,
-    covr
+    covr,
+    vcr (>= 0.6.0)
 RoxygenNote: 7.2.3
 X-schema.org-applicationCategory: Data Access
 X-schema.org-keywords: birds, birding, ebird, database, data, biology, observations, sightings, ornithology

--- a/tests/fixtures/ebirdchecklistfeed.yml
+++ b/tests/fixtures/ebirdchecklistfeed.yml
@@ -1,0 +1,110 @@
+http_interactions:
+- request:
+    method: get
+    uri: https://ebird.org/ws2.0/product/lists/L207391/2020/03/24?maxResults=200
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      X-eBirdApiToken: <<<redacted>>>
+  response:
+    status:
+      status_code: 200
+      category: Success
+      reason: OK
+      message: 'Success: (200) OK'
+    headers:
+      date: Wed, 17 Jan 2024 06:27:48 GMT
+      server: Apache
+      cache-control: no-cache, no-store, max-age=0, must-revalidate
+      content-encoding: gzip
+      content-type: application/json;charset=utf-8
+      expires: '0'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000 ; includeSubDomains
+      vary: Accept-Encoding,Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-content-type-options: nosniff
+      x-frame-options: DENY
+      x-xss-protection: 1; mode=block
+      transfer-encoding: chunked
+    body:
+      encoding: ''
+      file: no
+      string: '[{"locId":"L207391","subId":"S66174580","userDisplayName":"David Wood","numSpecies":10,"obsDt":"24
+        Mar 2020","obsTime":"14:47","isoObsDate":"2020-03-24 14:47","subID":"S66174580","loc":{"locId":"L207391","name":"Mount
+        Auburn Cemetery","latitude":42.371,"longitude":-71.146,"countryCode":"US","countryName":"United
+        States","subnational1Name":"Massachusetts","subnational1Code":"US-MA","subnational2Code":"US-MA-017","subnational2Name":"Middlesex","isHotspot":true,"locName":"Mount
+        Auburn Cemetery","lat":42.371,"lng":-71.146,"hierarchicalName":"Mount Auburn
+        Cemetery, Middlesex, Massachusetts, US","locID":"L207391"}},{"locId":"L207391","subId":"S66173590","userDisplayName":"Sofia
+        Prado-Irwin","numSpecies":15,"obsDt":"24 Mar 2020","obsTime":"14:31","isoObsDate":"2020-03-24
+        14:31","subID":"S66173590","loc":{"locId":"L207391","name":"Mount Auburn Cemetery","latitude":42.371,"longitude":-71.146,"countryCode":"US","countryName":"United
+        States","subnational1Name":"Massachusetts","subnational1Code":"US-MA","subnational2Code":"US-MA-017","subnational2Name":"Middlesex","isHotspot":true,"locName":"Mount
+        Auburn Cemetery","lat":42.371,"lng":-71.146,"hierarchicalName":"Mount Auburn
+        Cemetery, Middlesex, Massachusetts, US","locID":"L207391"}},{"locId":"L207391","subId":"S66194110","userDisplayName":"Jeffrey
+        Gantz","numSpecies":19,"obsDt":"24 Mar 2020","obsTime":"13:30","isoObsDate":"2020-03-24
+        13:30","subID":"S66194110","loc":{"locId":"L207391","name":"Mount Auburn Cemetery","latitude":42.371,"longitude":-71.146,"countryCode":"US","countryName":"United
+        States","subnational1Name":"Massachusetts","subnational1Code":"US-MA","subnational2Code":"US-MA-017","subnational2Name":"Middlesex","isHotspot":true,"locName":"Mount
+        Auburn Cemetery","lat":42.371,"lng":-71.146,"hierarchicalName":"Mount Auburn
+        Cemetery, Middlesex, Massachusetts, US","locID":"L207391"}},{"locId":"L207391","subId":"S66171158","userDisplayName":"Ann
+        Gurka","numSpecies":21,"obsDt":"24 Mar 2020","obsTime":"13:00","isoObsDate":"2020-03-24
+        13:00","subID":"S66171158","loc":{"locId":"L207391","name":"Mount Auburn Cemetery","latitude":42.371,"longitude":-71.146,"countryCode":"US","countryName":"United
+        States","subnational1Name":"Massachusetts","subnational1Code":"US-MA","subnational2Code":"US-MA-017","subnational2Name":"Middlesex","isHotspot":true,"locName":"Mount
+        Auburn Cemetery","lat":42.371,"lng":-71.146,"hierarchicalName":"Mount Auburn
+        Cemetery, Middlesex, Massachusetts, US","locID":"L207391"}},{"locId":"L207391","subId":"S71419937","userDisplayName":"Jacqui
+        Kluft","numSpecies":20,"obsDt":"24 Mar 2020","obsTime":"10:30","isoObsDate":"2020-03-24
+        10:30","subID":"S71419937","loc":{"locId":"L207391","name":"Mount Auburn Cemetery","latitude":42.371,"longitude":-71.146,"countryCode":"US","countryName":"United
+        States","subnational1Name":"Massachusetts","subnational1Code":"US-MA","subnational2Code":"US-MA-017","subnational2Name":"Middlesex","isHotspot":true,"locName":"Mount
+        Auburn Cemetery","lat":42.371,"lng":-71.146,"hierarchicalName":"Mount Auburn
+        Cemetery, Middlesex, Massachusetts, US","locID":"L207391"}},{"locId":"L207391","subId":"S70981564","userDisplayName":"Barbara
+        Olson","numSpecies":20,"obsDt":"24 Mar 2020","obsTime":"10:30","isoObsDate":"2020-03-24
+        10:30","subID":"S70981564","loc":{"locId":"L207391","name":"Mount Auburn Cemetery","latitude":42.371,"longitude":-71.146,"countryCode":"US","countryName":"United
+        States","subnational1Name":"Massachusetts","subnational1Code":"US-MA","subnational2Code":"US-MA-017","subnational2Name":"Middlesex","isHotspot":true,"locName":"Mount
+        Auburn Cemetery","lat":42.371,"lng":-71.146,"hierarchicalName":"Mount Auburn
+        Cemetery, Middlesex, Massachusetts, US","locID":"L207391"}},{"locId":"L207391","subId":"S66184472","userDisplayName":"Jason
+        Barcus","numSpecies":24,"obsDt":"24 Mar 2020","obsTime":"07:30","isoObsDate":"2020-03-24
+        07:30","subID":"S66184472","loc":{"locId":"L207391","name":"Mount Auburn Cemetery","latitude":42.371,"longitude":-71.146,"countryCode":"US","countryName":"United
+        States","subnational1Name":"Massachusetts","subnational1Code":"US-MA","subnational2Code":"US-MA-017","subnational2Name":"Middlesex","isHotspot":true,"locName":"Mount
+        Auburn Cemetery","lat":42.371,"lng":-71.146,"hierarchicalName":"Mount Auburn
+        Cemetery, Middlesex, Massachusetts, US","locID":"L207391"}}]'
+  recorded_at: 2024-01-17 06:27:49 GMT
+  recorded_with: vcr/1.2.2, webmockr/0.9.0
+- request:
+    method: get
+    uri: https://ebird.org/ws2.0/product/lists/LL207391/2020/03/25?maxResults=10
+    body:
+      encoding: ''
+      string: ''
+    headers:
+      Accept: application/json, text/xml, application/xml, */*
+      X-eBirdApiToken: <<<redacted>>>
+  response:
+    status:
+      status_code: 400
+      category: Client error
+      reason: Bad Request
+      message: 'Client error: (400) Bad Request'
+    headers:
+      date: Wed, 17 Jan 2024 06:27:49 GMT
+      server: Apache
+      cache-control: no-cache, no-store, max-age=0, must-revalidate
+      content-type: application/json
+      expires: '0'
+      pragma: no-cache
+      strict-transport-security: max-age=31536000 ; includeSubDomains
+      vary: Accept-Encoding,Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-content-type-options: nosniff
+      x-frame-options: DENY
+      x-xss-protection: 1; mode=block
+      content-encoding: gzip
+      content-length: '211'
+      connection: close
+    body:
+      encoding: ''
+      file: no
+      string: '{"errors":[{"status":"400 BAD_REQUEST","code":"methodInvocation","title":"Field
+        regionCode of recListsCmd: Property regionCode threw exception; nested exception
+        is java.lang.IllegalArgumentException: Unable to find matching region type
+        for LL207391"}]}'
+  recorded_at: 2024-01-17 06:27:49 GMT
+  recorded_with: vcr/1.2.2, webmockr/0.9.0

--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -1,0 +1,10 @@
+library("vcr") # *Required* as vcr is set up on loading
+invisible(vcr::vcr_configure(
+  filter_sensitive_data = list("<<<redacted>>>" = Sys.getenv('EBIRD_KEY')),
+  dir = vcr::vcr_test_path("fixtures")
+))
+vcr::check_cassette_names()
+# Create fake EBIRD_KEY if not present (e.g, on CI or CRAN)
+if (!nzchar(Sys.getenv("EBIRD_KEY"))) {
+  Sys.setenv("EBIRD_KEY" = "fake_key")
+}

--- a/tests/testthat/test-ebirdchecklistfeed.R
+++ b/tests/testthat/test-ebirdchecklistfeed.R
@@ -1,22 +1,27 @@
-context("ebirdchecklistfeed")
-
-test_that("ebirdchecklistfeed succeeds reproducibly", {
-  skip_on_cran()
-  skip_on_ci()
+vcr::use_cassette("ebirdchecklistfeed", {
   
-  out1 <- ebirdchecklistfeed(loc = "L207391", date = "2020-03-24", max = 3)
-  expect_is(out1, "data.frame")
-  expect_is(out1$userDisplayName, "character")
-  expect_equal(nrow(out1), 3)
-  expect_equal(ncol(out1), 9)
-})
-
-test_that("ebirdchecklistfeed errors for bad input", {
-  skip_on_cran()
-  skip_on_ci()
+  test_that("ebirdchecklistfeed succeeds reproducibly", {
+    # Check that max query was readjusted to 200 with warning
+    expect_warning(
+      out1 <- ebirdchecklistfeed(loc = "L207391", date = "2020-03-24", max = 250),
+      "Maximum number of results supplied was > 200, using 200."
+    )
+    # But the query is still successful
+    expect_is(out1, "data.frame")
+    expect_is(out1$userDisplayName, "character")
+    expect_equal(nrow(out1), 7)
+    expect_equal(ncol(out1), 9)
+  })
   
-  expect_warning(ebirdchecklistfeed(loc = "L207391", date = "2020-03-24", max = 250))
-  expect_error(ebirdchecklistfeed(loc = "L207391", date = "2121-03-25"))
-  expect_error(ebirdchecklistfeed(loc = "L207391", date = "03-25-2020"))
-  expect_error(ebirdchecklistfeed(loc = "LL207391", date = "2020-03-25", max = 10))
+  test_that("ebirdchecklistfeed errors for bad input", {
+    # Bad location ID
+    expect_error(ebirdchecklistfeed(loc = "LL207391", date = "2020-03-25", max = 10))
+  })
+  
+  test_that("ebirdchecklistfeed errors locally", {
+    # Bad dates
+    expect_error(ebirdchecklistfeed(loc = "L207391", date = "2121-03-25"))
+    expect_error(ebirdchecklistfeed(loc = "L207391", date = "03-25-2020"))
+  })
+  
 })


### PR DESCRIPTION
This implements CI test-coverage method number 2 from [#91](https://github.com/ropensci/rebird/issues/91#issuecomment-1897871913).

Old test coverage for ebirdchecklistfeed.R [0.00%](https://github.com/ropensci/rebird/actions/runs/7604007177/job/20706407580)
New test coverage for ebirdchecklistfeed.R [92.31%](https://github.com/ropensci/rebird/actions/runs/7605871576/job/20710778460?pr=105)

See the [HTTP Testing in R book](https://books.ropensci.org/http-testing) and the [vcr package](https://github.com/ropensci/vcr/).

With this method, no API secrets are used on CI or CRAN.  CI or CRAN can use recordings of HTTP requests produced locally by the VCR package as YML files. The EBIRD_KEY api key is automatically redacted from the HTTP headers in the YML files based on the setup in helper-vcr.R. Local testing (or testing on CI using GitHub secrets) could periodically be done with real API keys to make sure the API output hasn't changed.