### PR TITLE
Add documentation and tests to check for exoticCategory column

### DIFF
--- a/R/ebirdchecklist.R
+++ b/R/ebirdchecklist.R
@@ -32,7 +32,10 @@
 #' @return "speciesCode" species codes reported on checklist
 #' @return "obsId" observation IDs for each taxon on checklist
 #' @return "howManyStr" number of individuals reported for each taxon
-#' @return "exoticCategory" exotic species categories for each taxon
+#' @return "exoticCategory":  If applicable, exotic species category. This column will be provided
+#'    if there are exotics or introduced species in the query. Return values are "N" for naturalized,
+#'    "P" for provisional, "X" for escapee, and NA for native. For more information see
+#'    \url{support.ebird.org/en/support/solutions/articles/48001218430}.
 #' @return "obsComments" observation comments for each taxon
 #' @return "photoCounts" number of photos for each taxon
 #' @return "audioCounts" number of audio files for each taxon

--- a/R/ebirdgeo.R
+++ b/R/ebirdgeo.R
@@ -47,6 +47,10 @@
 #' @return "obsValid": TRUE if observation has been deemed valid by either the
 #'    automatic filters or a regional viewer, FALSE otherwise
 #' @return "sciName" species' scientific name
+#' @return "exoticCategory":  If applicable, exotic species category. This column will be provided
+#'    if there are exotics or introduced species in the query. Return values are "N" for naturalized,
+#'    "P" for provisional, "X" for escapee, and NA for native. For more information see
+#'    \url{support.ebird.org/en/support/solutions/articles/48001218430}.
 #' @export
 #' @examples \dontrun{
 #' ebirdgeo('amegfi', 42, -76) # American Goldfinch

--- a/R/ebirdhistorical.R
+++ b/R/ebirdhistorical.R
@@ -43,7 +43,10 @@
 #' @return "obsReviewed": TRUE if observation has been reviewed, FALSE otherwise
 #' @return "locationPrivate": TRUE if location is not a birding hotspot
 #' @return "subID": submission ID
-#' @return "exoticCategory": exotic species category
+#' @return "exoticCategory":  If applicable, exotic species category. This column will be provided
+#'    if there are exotics or introduced species in the query. Return values are "N" for naturalized,
+#'    "P" for provisional, "X" for escapee, and NA for native. For more information see
+#'    \url{support.ebird.org/en/support/solutions/articles/48001218430}.
 #' @return "subnational2Code": county code (returned if simple=FALSE)
 #' @return "subnational2Name": county name (returned if simple=FALSE)
 #' @return "subnational1Code": state/province ISO code (returned if simple=FALSE)

--- a/R/ebirdnotable.R
+++ b/R/ebirdnotable.R
@@ -50,7 +50,10 @@
 #' @return "locationPrivate": TRUE if location is not a birding hotspot
 #'    automatic filters or a regional viewer, FALSE otherwise
 #' @return "subId": submission ID
-#' @return "exoticCategory": Exotic category
+#' @return "exoticCategory":  If applicable, exotic species category. This column will be provided
+#'    if there are exotics or introduced species in the query. Return values are "N" for naturalized,
+#'    "P" for provisional, "X" for escapee, and NA for native. For more information see
+#'    \url{support.ebird.org/en/support/solutions/articles/48001218430}.
 #' @return "subnational2Code": county code (returned if simple=FALSE)
 #' @return "subnational2Name": county name (returned if simple=FALSE)
 #' @return "subnational1Code": state/province ISO code (returned if simple=FALSE)

--- a/R/ebirdregion.R
+++ b/R/ebirdregion.R
@@ -44,6 +44,10 @@
 #' @return "obsReviewed": TRUE if observation has been reviewed, FALSE otherwise
 #' @return "locationPrivate": TRUE if location is not a birding hotspot
 #' @return "subId": submission ID
+#' @return "exoticCategory":  If applicable, exotic species category. This column will be provided
+#'    if there are exotics or introduced species in the query. Return values are "N" for naturalized,
+#'    "P" for provisional, "X" for escapee, and NA for native. For more information see
+#'    \url{support.ebird.org/en/support/solutions/articles/48001218430}.
 #' @export
 #' @examples \dontrun{
 #' ebirdregion(loc = 'US', species = 'btbwar')

--- a/R/nearestobs.R
+++ b/R/nearestobs.R
@@ -49,6 +49,10 @@
 #' @return "obsReviewed": TRUE if observation has been reviewed, FALSE otherwise
 #' @return "locationPrivate": TRUE if location is not a birding hotspot
 #' @return "subId": submission ID
+#' @return "exoticCategory":  If applicable, exotic species category. This column will be provided
+#'    if there are exotics or introduced species in the query. Return values are "N" for naturalized,
+#'    "P" for provisional, "X" for escapee, and NA for native. For more information see
+#'    \url{support.ebird.org/en/support/solutions/articles/48001218430}.
 #' @export
 #' 
 #' @author Rafael Maia \email{rm72@@zips.uakron.edu},

--- a/tests/testthat/test-ebirdchecklist.R
+++ b/tests/testthat/test-ebirdchecklist.R
@@ -20,6 +20,11 @@ vcr::use_cassette("ebirdchecklist", {
     expect_true('audioCounts' %in% colnames(out2))
     expect_equal(nrow(out2), 2)
 
+    # Returns exoticCategory or doesn't, depending on whether it is in the checklist
+    expect_true('exoticCategory' %in% colnames(out1))
+    expect_false('exoticCategory' %in% colnames(out2))
+
+
   })
 
   test_that("ebirdchecklist errors for bad input", {


### PR DESCRIPTION
## Description

I've added documentation strings to all of the methods which _can_ return exoticCategory. I've also added a test to one of these, showing how I think we should test for it - but I would like advice on whether or not this is the right approach before copying this to other tests. 

## Related Issue
Closes #129.